### PR TITLE
Fixed incorrect constraints between first scans

### DIFF
--- a/slam_toolbox/lib/karto_sdk/src/Mapper.cpp
+++ b/slam_toolbox/lib/karto_sdk/src/Mapper.cpp
@@ -1513,7 +1513,7 @@ namespace karto
         kt_double response = m_pMapper->m_pSequentialScanMatcher->MatchScan<LocalizedRangeScanMap>(pScan,
                                                                   pSensorManager->GetScans(rCandidateSensorName),
                                                                   bestPose, covariance);
-        LinkScans(pScan, pSensorManager->GetScan(rCandidateSensorName, 0), bestPose, covariance);
+        LinkScans(pSensorManager->GetScan(rCandidateSensorName, 0), pScan, bestPose, covariance);
 
         // only add to means and covariances if response was high "enough"
         if (response > m_pMapper->m_pLinkMatchMinimumResponseFine->GetValue())


### PR DESCRIPTION
Constraint between first scans are now computed correctly, instead of just computing zero