### PR TITLE
Multi should process scan

### DIFF
--- a/slam_toolbox/launch/robosar_mapping.launch
+++ b/slam_toolbox/launch/robosar_mapping.launch
@@ -5,7 +5,7 @@
     <!-- Agent bringup -->
     <include file="$(find robosar_agent_bringup)/launch/robosar_agent_bringup_node.launch"/>
     <!-- Run SLAM Toolbox for mapping -->
-    <node pkg="slam_toolbox" type="async_slam_toolbox_node" name="slam_toolbox" output="screen">
+    <node pkg="slam_toolbox" type="sync_slam_toolbox_node" name="slam_toolbox" output="screen">
         <rosparam command="load" file="$(find slam_toolbox)/config/robosar_mapping.yaml" />
         <param name="odom_frame" type="string" value="$(arg agentN)/odom" />
         <param name="base_frame" type="string" value="$(arg agentN)/base_link" />
@@ -18,5 +18,5 @@
     <!-- Teleoperation -->
     <node name="teleop_twist_keyboard" pkg="teleop_twist_keyboard" type="teleop_twist_keyboard.py" output="screen">
         <remap from="cmd_vel" to="/robosar_agent_bringup_node/$(arg agentN)/control"/>
-  </node>
+    </node>
 </launch>

--- a/slam_toolbox/src/slam_toolbox_common.cpp
+++ b/slam_toolbox/src/slam_toolbox_common.cpp
@@ -456,17 +456,26 @@ bool SlamToolbox::shouldProcessScan(
   const karto::Pose2& pose)
 /*****************************************************************************/
 {
-  static karto::Pose2 last_pose;
-  static ros::Time last_scan_time = ros::Time(0.);
+  static std::vector<std::string> scan_frame_ids;
+  static std::map<std::string, karto::Pose2> last_poses;
+  static std::map<std::string, ros::Time> last_scan_times;
   static double min_dist2 =
     smapper_->getMapper()->getParamMinimumTravelDistance() *
     smapper_->getMapper()->getParamMinimumTravelDistance();
-
+  // Check if frame_id of current scan is new
+  bool new_scan_frame_id = false;
+  std::string cur_frame_id = scan->header.frame_id;
+  if (std::find(scan_frame_ids.begin(), scan_frame_ids.end(), cur_frame_id) == scan_frame_ids.end()){
+    // New scan
+    new_scan_frame_id = true;
+    scan_frame_ids.push_back(cur_frame_id);
+    last_scan_times[cur_frame_id] = ros::Time(0.);
+  }
   // we give it a pass on the first measurement to get the ball rolling
-  if (first_measurement_)
+  if (first_measurement_ || new_scan_frame_id)
   {
-    last_scan_time = scan->header.stamp;
-    last_pose = pose;
+    last_scan_times[cur_frame_id] = scan->header.stamp;
+    last_poses[cur_frame_id] = pose;
     first_measurement_ = false;
     return true;
   }
@@ -484,20 +493,20 @@ bool SlamToolbox::shouldProcessScan(
   }
 
   // not enough time
-  if (scan->header.stamp - last_scan_time < minimum_time_interval_)
+  if (scan->header.stamp - last_scan_times[cur_frame_id] < minimum_time_interval_)
   {
     return false;
   }
 
   // check moved enough, within 10% for correction error
-  const double dist2 = last_pose.SquaredDistance(pose);
+  const double dist2 = last_poses[cur_frame_id].SquaredDistance(pose);
   if(dist2 < 0.8 * min_dist2 || scan->header.seq < 5)
   {
     return false;
   }
 
-  last_pose = pose;
-  last_scan_time = scan->header.stamp; 
+  last_poses[cur_frame_id] = pose;
+  last_scan_times[cur_frame_id] = scan->header.stamp; 
 
   return true;
 }


### PR DESCRIPTION
Previously, ShouldProcessScan only worked for single robot. This was fine in sim since both agents started with different odom poses; but in real life both agents start with odom pose (0,0,0), which causes the system to ignore scans from the second agent to come online. This is fixed by moving both agents, but this is a bad solution; this PR is a better solution. Here, the frame_id of the scans are used to distinguish between agents, thus allowing both agents to contribute scans.