### PR TITLE
Removed should process check from apriltag callback

### DIFF
--- a/slam_toolbox/include/slam_toolbox/slam_toolbox_common.hpp
+++ b/slam_toolbox/include/slam_toolbox/slam_toolbox_common.hpp
@@ -91,7 +91,7 @@ protected:
   bool updateMap();
   tf2::Stamped<tf2::Transform> setTransformFromPoses(const karto::Pose2& pose,
     const karto::Pose2& karto_pose, const std_msgs::Header& header, const bool& update_reprocessing_transform);
-  tf2::Stamped<tf2::Transform> setTagTransformFromPoses(int tag_id);
+  tf2::Stamped<tf2::Transform> publishTagTransform(int tag_id);
   karto::LocalizedRangeScan* getLocalizedRangeScan(karto::LaserRangeFinder* laser,
     const sensor_msgs::LaserScan::ConstPtr& scan,
     karto::Pose2& karto_pose);

--- a/slam_toolbox/include/slam_toolbox/slam_toolbox_sync.hpp
+++ b/slam_toolbox/include/slam_toolbox/slam_toolbox_sync.hpp
@@ -40,7 +40,7 @@ protected:
     slam_toolbox_msgs::DeserializePoseGraph::Response& resp) override final;
 
   std::queue<PosedScan> q_;
-  std::map<std::string, std::queue<apriltag_ros::AprilTagDetectionArray::ConstPtr> > apriltags_q_;
+  std::map<std::string, std::queue<apriltag_ros::AprilTagDetectionArray::ConstPtr> > agent_apriltags_q_m_;
   ros::ServiceServer ssClear_;
   boost::mutex apriltag_q_mutex_;
 };

--- a/slam_toolbox/include/slam_toolbox/slam_toolbox_sync.hpp
+++ b/slam_toolbox/include/slam_toolbox/slam_toolbox_sync.hpp
@@ -38,13 +38,11 @@ protected:
   bool clearQueueCallback(slam_toolbox_msgs::ClearQueue::Request& req, slam_toolbox_msgs::ClearQueue::Response& resp);
   virtual bool deserializePoseGraphCallback(slam_toolbox_msgs::DeserializePoseGraph::Request& req,
     slam_toolbox_msgs::DeserializePoseGraph::Response& resp) override final;
-  bool shouldProcessTag(std:: string frame_id);
 
   std::queue<PosedScan> q_;
   std::map<std::string, std::queue<apriltag_ros::AprilTagDetectionArray::ConstPtr> > apriltags_q_;
   ros::ServiceServer ssClear_;
   boost::mutex apriltag_q_mutex_;
-  std::map<std::string, bool> should_process_;
 };
 
 }

--- a/slam_toolbox/include/slam_toolbox/toolbox_types.hpp
+++ b/slam_toolbox/include/slam_toolbox/toolbox_types.hpp
@@ -41,17 +41,11 @@ namespace toolbox_types
 struct PosedScan
 {
   PosedScan(sensor_msgs::LaserScan::ConstPtr scan_in, karto::Pose2 pose_in) :
-             scan(scan_in), pose(pose_in)
-  {
-    apriltags = nullptr;
-  }
-  PosedScan(sensor_msgs::LaserScan::ConstPtr scan_in, karto::Pose2 pose_in, apriltag_ros::AprilTagDetectionArray::ConstPtr apriltags_in) :
-             scan(scan_in), pose(pose_in), apriltags(apriltags_in)
+             scan(scan_in), pose(pose_in) 
   {
   }
   sensor_msgs::LaserScan::ConstPtr scan;
   karto::Pose2 pose;
-  apriltag_ros::AprilTagDetectionArray::ConstPtr apriltags;
 };
 
 // object containing a vertex pointer and an updated score

--- a/slam_toolbox/launch/robosar_mapping.launch
+++ b/slam_toolbox/launch/robosar_mapping.launch
@@ -5,18 +5,15 @@
     <!-- Agent bringup -->
     <include file="$(find robosar_agent_bringup)/launch/robosar_agent_bringup_node.launch"/>
     <!-- Run SLAM Toolbox for mapping -->
-    <node pkg="slam_toolbox" type="async_slam_toolbox_node" name="slam_toolbox" output="screen">
+    <node pkg="slam_toolbox" type="sync_slam_toolbox_node" name="slam_toolbox" output="screen">
         <rosparam command="load" file="$(find slam_toolbox)/config/robosar_mapping.yaml" />
-        <param name="odom_frame" type="string" value="$(arg agentN)/odom" />
-        <param name="base_frame" type="string" value="$(arg agentN)/base_link" />
-        <param name="scan_topic" type="string" value="/robosar_agent_bringup_node/$(arg agentN)/feedback/scan" />
     </node>
     <!-- Set maximum laser range -->
     <param name="/slam_toolbox/max_laser_range" type="double" value="4.0" />
     <!-- Launch RVIZ with provided configurations -->
-    <node type="rviz" name="rviz" pkg="rviz" args="-d $(find slam_toolbox)/config/robosar_mapping.rviz" />
+    <node type="rviz" name="rviz" pkg="rviz" args="-d $(find robosar_gazebo_sim)/config/run_slam_sim.rviz" />
     <!-- Teleoperation -->
-    <node name="teleop_twist_keyboard" pkg="teleop_twist_keyboard" type="teleop_twist_keyboard.py" output="screen">
-        <remap from="cmd_vel" to="/robosar_agent_bringup_node/$(arg agentN)/control"/>
+    <node name="teleop_twist_keyboard_$(arg agentN)" pkg="teleop_twist_keyboard" type="teleop_twist_keyboard.py" output="screen">
+        <remap from="cmd_vel" to="/robosar_agent_bringup_node/$(arg agentN)/cmd_vel"/>
   </node>
 </launch>

--- a/slam_toolbox/src/slam_toolbox_common.cpp
+++ b/slam_toolbox/src/slam_toolbox_common.cpp
@@ -651,6 +651,7 @@ void SlamToolbox::addTag(apriltag_ros::AprilTagDetectionArray::ConstPtr& aprilta
   boost::mutex::scoped_lock lock_s(smapper_mutex_);
   if (scan == nullptr) ROS_ERROR("\r\n\r\n\r\n\r\n\r\n**** SCAN POINTER IS NULL ****\r\n\r\n\r\n\r\n\r\n");
   for (apriltag_ros::AprilTagDetection tag : apriltag->detections) {
+    // Only consider apriltag ids you have not seen before
     // assume not group of tags
     if (m_apriltag_to_scan_.find(tag.id[0]) == m_apriltag_to_scan_.end())
       m_apriltag_to_scan_[tag.id[0]] = std::make_pair(tag.pose, scan);

--- a/slam_toolbox/src/slam_toolbox_common.cpp
+++ b/slam_toolbox/src/slam_toolbox_common.cpp
@@ -232,7 +232,7 @@ void SlamToolbox::publishTransformLoop(const double& transform_publish_period)
     {
       std::map<int, std::pair<geometry_msgs::PoseWithCovarianceStamped, karto::LocalizedRangeScan*>>::iterator iter;
       for (iter = m_apriltag_to_scan_.begin(); iter != m_apriltag_to_scan_.end(); iter++) {
-        setTagTransformFromPoses(iter->first);
+        publishTagTransform(iter->first);
       }
     }
 
@@ -446,7 +446,7 @@ tf2::Stamped<tf2::Transform> SlamToolbox::setTransformFromPoses(
 
 
 /*****************************************************************************/
-tf2::Stamped<tf2::Transform> SlamToolbox::setTagTransformFromPoses(int tag_id) {
+tf2::Stamped<tf2::Transform> SlamToolbox::publishTagTransform(int tag_id) {
 /*****************************************************************************/
   boost::mutex::scoped_lock lock(map_to_tags_mutex_);
   geometry_msgs::PoseWithCovarianceStamped scan_to_tag = m_apriltag_to_scan_[tag_id].first;
@@ -655,7 +655,7 @@ void SlamToolbox::addTag(apriltag_ros::AprilTagDetectionArray::ConstPtr& aprilta
     // assume not group of tags
     if (m_apriltag_to_scan_.find(tag.id[0]) == m_apriltag_to_scan_.end())
       m_apriltag_to_scan_[tag.id[0]] = std::make_pair(tag.pose, scan);
-    setTagTransformFromPoses(tag.id[0]);
+    publishTagTransform(tag.id[0]);
   }
 }
  

--- a/slam_toolbox/src/slam_toolbox_sync.cpp
+++ b/slam_toolbox/src/slam_toolbox_sync.cpp
@@ -66,7 +66,7 @@ void SynchronousSlamToolbox::run()
         std::getline(ss, frame_id, '/');
         boost::mutex::scoped_lock lock(apriltag_q_mutex_);
         // Get this agent's queue
-        std::queue<apriltag_ros::AprilTagDetectionArray::ConstPtr>& cur_queue = apriltags_q_[frame_id];
+        std::queue<apriltag_ros::AprilTagDetectionArray::ConstPtr>& cur_queue = agent_apriltags_q_m_[frame_id];
         // Go through entire queue
         while(!cur_queue.empty()){
           addTag(cur_queue.front(), karto_scan);
@@ -124,12 +124,12 @@ void SynchronousSlamToolbox::apriltagCallback(const apriltag_ros::AprilTagDetect
   std::getline(ss, frame_id, '/');
   // Put non-empty apriltag array into map
   if (apriltags->detections.size() > 0 && apriltags->detections[0].id.size() > 0) {
-    if (apriltags_q_.find(frame_id) == apriltags_q_.end())
-      apriltags_q_[frame_id] = std::queue<apriltag_ros::AprilTagDetectionArray::ConstPtr>();
+    if (agent_apriltags_q_m_.find(frame_id) == agent_apriltags_q_m_.end())
+      agent_apriltags_q_m_[frame_id] = std::queue<apriltag_ros::AprilTagDetectionArray::ConstPtr>();
     // Push to queue if size permits
     // Queue reflects apriltags detected by this agent over time
-    if(apriltags_q_[frame_id].size() < 10)
-      apriltags_q_[frame_id].push(apriltags);
+    if(agent_apriltags_q_m_[frame_id].size() < 10)
+      agent_apriltags_q_m_[frame_id].push(apriltags);
   }
 }
 

--- a/slam_toolbox/src/slam_toolbox_sync.cpp
+++ b/slam_toolbox/src/slam_toolbox_sync.cpp
@@ -55,10 +55,24 @@ void SynchronousSlamToolbox::run()
           (int)q_.size());
       }
 
+      // Process scan with pose
       karto::LocalizedRangeScan* karto_scan = addScan(getLaser(scan_w_pose.scan), scan_w_pose);
-      if (karto_scan) 
-        addTag(scan_w_pose.apriltags, karto_scan);
-      continue;
+      // Tie this agent's pose with this agent's apriltag array detections
+      if (karto_scan)
+      {
+        // Get this agent's name
+        std::stringstream ss(scan_w_pose.scan->header.frame_id);
+        std::string frame_id;
+        std::getline(ss, frame_id, '/');
+        boost::mutex::scoped_lock lock(apriltag_q_mutex_);
+        // Get this agent's queue
+        std::queue<apriltag_ros::AprilTagDetectionArray::ConstPtr>& cur_queue = apriltags_q_[frame_id];
+        // Go through entire queue
+        while(!cur_queue.empty()){
+          addTag(cur_queue.front(), karto_scan);
+          cur_queue.pop();
+        }
+      }
     }
 
     r.sleep();
@@ -92,22 +106,10 @@ void SynchronousSlamToolbox::laserCallback(
     return;
   }
 
-  std::stringstream ss(scan->header.frame_id);
-  std::string frame_id;
-  std::getline(ss, frame_id, '/');
-  boost::mutex::scoped_lock lock(apriltag_q_mutex_);
-  should_process_[frame_id] = shouldProcessScan(scan, pose);
-
   // if sync and valid, add to queue
-  if (should_process_[frame_id])
+  if (shouldProcessScan(scan, pose))
   {
-    // find if apriltag was detected for agent, assumes laser_frame = apriltag_frame
-    if (apriltags_q_.find(frame_id) != apriltags_q_.end() && !apriltags_q_[frame_id].empty()) {
-      q_.push(PosedScan(scan, pose, apriltags_q_[frame_id].front()));
-      apriltags_q_[frame_id].pop();
-    } else {
-      q_.push(PosedScan(scan, pose));
-    }
+    q_.push(PosedScan(scan, pose));
   }
 
   return;
@@ -120,19 +122,15 @@ void SynchronousSlamToolbox::apriltagCallback(const apriltag_ros::AprilTagDetect
   std::stringstream ss(apriltags->header.frame_id);
   std::string frame_id;
   std::getline(ss, frame_id, '/');
-  if (shouldProcessTag(frame_id) && apriltags->detections.size() > 0 && apriltags->detections[0].id.size() > 0) {
+  // Put non-empty apriltag array into map
+  if (apriltags->detections.size() > 0 && apriltags->detections[0].id.size() > 0) {
     if (apriltags_q_.find(frame_id) == apriltags_q_.end())
       apriltags_q_[frame_id] = std::queue<apriltag_ros::AprilTagDetectionArray::ConstPtr>();
-    apriltags_q_[frame_id].push(apriltags);
-    should_process_[frame_id] = false;
+    // Push to queue if size permits
+    // Queue reflects apriltags detected by this agent over time
+    if(apriltags_q_[frame_id].size() < 10)
+      apriltags_q_[frame_id].push(apriltags);
   }
-}
-
-/*****************************************************************************/
-bool SynchronousSlamToolbox::shouldProcessTag(std:: string frame_id) {
-/*****************************************************************************/
-  if (should_process_.find(frame_id) == should_process_.end()) return false;
-  return should_process_[frame_id];
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
Removed should process check, which allowed few other simplifications. For example no longer need to add apriltag to scan_w_pose, allowing reverting back to original definition. Also updated documentation / names for clarity. Also process entire queue of apriltag detections, instead of just head of list, per node